### PR TITLE
Check own properties for stem objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function getImportantWords(node) {
                 'parent': parent
             };
 
-            if (!(stem in words)) {
+            if (!(words.hasOwnProperty(stem))) {
                 words[stem] = {
                     'matches': [match],
                     'stem': stem,
@@ -264,11 +264,9 @@ function getKeyphrases(results, maximum) {
     var score;
     var first;
     var match;
-
     /*
      * Iterate over all grouped important words...
      */
-
     for (keyword in results) {
         matches = results[keyword].matches;
         length = matches.length;
@@ -280,7 +278,7 @@ function getKeyphrases(results, maximum) {
 
         while (++index < length) {
             phrase = findPhrase(matches[index]);
-            stemmedPhrase = stemmedPhrases[phrase.value];
+            stemmedPhrase = stemmedPhrases.hasOwnProperty(phrase.value) && stemmedPhrases[phrase.value];
             first = phrase.nodes[0];
 
             match = {
@@ -292,7 +290,6 @@ function getKeyphrases(results, maximum) {
              * If we've detected the same stemmed
              * phrase somewhere.
              */
-
             if (stemmedPhrase) {
                 /*
                  * Add weight per phrase to the score of


### PR DESCRIPTION
The commit sent in https://github.com/wooorm/retext-keywords/issues/5 didn't fix the issue. I traced the exception and found that the problem was the stem `"constructor"` was clashing with the inherited [Object.prototype.constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor) property. I've added the `hasOwnProperty` check as needed so the inherited properties are ignored. It may be required in some other place, but at least this enough to fix the `constructor` case.

